### PR TITLE
Run build script on server side.

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -1,4 +1,4 @@
 {
-  "wattsiPath": "/home/your-user/wattsi/bin/wattsi",
+  "buildScriptPath": "/home/your-user/wattsi/bin/wattsi",
   "port": "8080"
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -30,26 +30,28 @@ app.use(function* () {
     this.throw("Expected a source file", 400);
   }
   const sourceFilePath = parts.file.source.path;
+  const sourceDirPath = path.dirname(parts.file.source.path);
 
-  if (!parts.file.caniuse) {
-    this.throw("Expected caniuse file", 400);
-  }
-  const caniuseFilePath = parts.file.caniuse.path;
-
-  if (!parts.file.w3cbugs) {
-    this.throw("Expected w3cbugs file", 400);
-  }
-  const w3cbugsFilePath = parts.file.w3cbugs.path;
+  const quiet = parts.field.quiet !== undefined ? "--quiet" : "";
+  const verbose = parts.field.verbose !== undefined ? "--verbose" : "";
 
   const outDirectory = randomDirectoryName();
   yield mkdirp(outDirectory);
 
+  const tempDirectory = outDirectory + "/.temp";
+
   try {
     try {
-      const result = yield execFile(config.wattsiPath, [sourceFilePath, outDirectory, caniuseFilePath, w3cbugsFilePath]);
+      if (".zip" === path.extname(sourceFilePath)) {
+        yield execFile("7za", ["e", sourceFilePath, "-o" + sourceDirPath]);
+      }
 
-      const outputFile = path.join(outDirectory, "output.txt");
-      yield fs.writeFile(outputFile, `${result.stdout}\n\n${result.stderr}`, { encoding: "utf-8" });
+      const args = ["--output", outDirectory, "--log", outDirectory,
+        "--cache", outDirectory + "/.cache", "--temp", outDirectory + "/.temp",
+        "--skip-install", quiet, verbose, sourceDirPath + "/source"]
+
+      const result = yield execFile(config.buildScriptPath, args);
+
     } catch (e) {
       if (e.stdout) {
         e.message = `${e.stdout}\n\n${e.stderr}`;
@@ -57,8 +59,13 @@ app.use(function* () {
       this.throw(e, 400);
     }
 
-    const zipFilePath = `${outDirectory}.zip`;
-    yield execFile("7za", ["a", "-tzip", "-r", zipFilePath, `./${outDirectory}/*`]);
+    const wattsiOutput = tempDirectory + "/wattsi-output";
+
+    yield execFile("mv", [outDirectory + "/build.log", wattsiOutput]);
+    yield execFile("mv", [outDirectory + "/entities.json", wattsiOutput]);
+
+    const zipFilePath = `${wattsiOutput}.zip`;
+    yield execFile("7za", ["a", "-tzip", "-r", zipFilePath, `./${wattsiOutput}/\*`]);
 
     this.type = "application/zip";
     this.body = fs.createReadStream(zipFilePath);
@@ -68,6 +75,7 @@ app.use(function* () {
     });
   } finally {
     yield rimraf(outDirectory);
+    parts.dispose();
   }
 });
 


### PR DESCRIPTION
Relates to https://github.com/whatwg/html-build/pull/28

This is part of the fix for the problem of making the build service report the correct line numbers when a source file has parser errors. But beyond that, it is part of enabling users to run the build with zero dependencies installed locally other than bash, zip/unzip, and git.

This requires the html/build/build.sh script to be installed on the server and pointed to in the config file (in place of pointing to the wattsi binary).